### PR TITLE
Add Document-Embedded Header and Footer Support to Pagination

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 # TipTap Pagination Plus
 [![NPM](https://img.shields.io/npm/v/tiptap-pagination-plus.svg)](https://www.npmjs.com/package/tiptap-pagination-plus)
 
-`tiptap-pagination-plus` extension that adds pagination support to your editor with table handling capabilities.
-
+`tiptap-pagination-plus` extension that adds pagination support to your editor with table handling capabilities, and now supports persistent, document-embedded headers and footers.
 
 # Demo
 
@@ -12,7 +11,7 @@ https://romikmakavana.me/tiptap-pagination/
 
 ```bash
 npm install tiptap-pagination-plus
-```  
+```
 
 ## Usage
 
@@ -21,34 +20,70 @@ npm install tiptap-pagination-plus
 ```typescript
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
+import Document from '@tiptap/extension-document'
 import { 
   PaginationPlus,
   TablePlus,
   TableRowPlus,
   TableCellPlus,
-  TableHeaderPlus
+  TableHeaderPlus,
+  HeaderNode,
+  FooterNode
 } from 'tiptap-pagination-plus'
 
 const editor = new Editor({
   extensions: [
-    StarterKit,
+    StarterKit.configure({
+                document: false,
+            }),
     TablePlus,
     TableRowPlus,
     TableCellPlus,
     TableHeaderPlus,
+    HeaderNode, // <-- Add this for header support
+    FooterNode, // <-- Add this for footer support
+    Document.extend({
+                content: "header? block+ footer?"
+            }),
     PaginationPlus.configure({
       pageHeight: 842,        // Height of each page in pixels
       pageGap: 20,           // Gap between pages in pixels
       pageBreakBackground: "#f7f7f7",  // Background color for page gaps
       pageHeaderHeight: 50,   // Height of page header/footer in pixels
-      footerRight: "Made with ❤️ by Romik",
-      footerLeft: "Page {page}",
-      headerLeft: "Header Left",
-      headerRight: "Header Right",
+      footerRight: "Made with ❤️ by Romik", // Fallback if no footer node
+      footerLeft: "Page {page}",           // Fallback if no footer node
+      headerLeft: "Header Left",           // Fallback if no header node
+      headerRight: "Header Right",         // Fallback if no header node
     }),
   ],
 })
 ```
+
+### Document-Embedded Header and Footer
+
+You can now add a `header` or `footer` node to your document. The content of these nodes will be rendered as the header and footer on every page, and are part of the document structure (they can be edited, saved, and loaded like any other content).
+
+- **Header/Footer Node Precedence:**
+  - If a `header` or `footer` node exists in the document, its content is used for the header/footer on every page.
+  - If not, the configuration options (`headerLeft`, `footerRight`, etc.) are used as a fallback.
+
+#### Example: Adding a Header/Footer Node
+
+```typescript
+// Insert a header node 
+editor.commands.setHeaderContent(content);
+
+// Insert a footer node at the end of the document
+editor.commands.setFooterContent(content);
+```
+
+- The `{page}` variable in the footer node will be replaced with the current page number.
+- You can use any valid ProseMirror/Tiptap content inside the header/footer nodes.
+
+#### Editing Header/Footer Content
+
+- The header and footer nodes are part of the document and can be set using commands. Editing in the UI directly is slightly more complicated, because what's actually being presented is the DecorationSet and not the Node itself.
+- They can be styled, saved, and loaded like any other node.
 
 ### Table Pagination
 
@@ -65,21 +100,22 @@ Key points for table pagination:
 | `pageGap` | number | 20 | Gap between pages in pixels |
 | `pageBreakBackground` | string | "#f7f7f7" | Background color for page gaps |
 | `pageHeaderHeight` | number | 50 | Height of page header/footer in pixels |
-| `footerRight` | string | "" | Custom text to display in the footer right side |
-| `footerLeft` | string | "" | Custom text to display in the footer left side |
-| `headerRight` | string | "" | Custom text to display in the header right side |
-| `headerLeft` | string | "" | Custom text to display in the header left side |
+| `footerRight` | string | "" | Custom text to display in the footer right side (used if no footer node) |
+| `footerLeft` | string | "" | Custom text to display in the footer left side (used if no footer node) |
+| `headerRight` | string | "" | Custom text to display in the header right side (used if no header node) |
+| `headerLeft` | string | "" | Custom text to display in the header left side (used if no header node) |
 
 ### Features
 
 - Automatic page breaks based on content height
 - Page numbers in the footer
-- Custom header/footer text support
-- use `{page}` variable to display current page number in header/footer text
+- Custom header/footer text support via document nodes or config
+- Use `{page}` variable to display current page number in header/footer text
 - Table pagination with header preservation
 - Responsive design
 - Automatic page height calculation
 - Support for nested content
+- **Header and footer are now part of the document structure and can be edited**
 
 ## License
 

--- a/src/Footer.ts
+++ b/src/Footer.ts
@@ -1,0 +1,58 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    footer: {
+      setFooterContent: (content: string) => ReturnType;
+    };
+  }
+}
+
+export const FooterNode = Node.create({
+    name: 'footer',
+    group: 'pageStructure',
+    content: 'block+',
+    defining: true,
+    isolated: true,
+  
+    parseHTML() {
+      return [{ tag: 'div[data-type="footer"]' }];
+    },
+  
+    renderHTML({ HTMLAttributes }) {
+      // This node itself is not rendered visually in the main document flow
+      // It only serves as a container for the master content.
+      return ['div', { ...HTMLAttributes, 'data-type': 'footer', style: 'display: none;' }, 0];
+    },
+
+    addCommands() {
+      return {
+        setFooterContent:
+          (content: string) =>
+          ({ tr, state, dispatch }) => {
+            if (!dispatch) return false;
+            
+            const { schema } = state;
+            const footerNodeType = schema.nodes.footer;
+            
+            // Create a paragraph with the content
+            const paragraph = schema.nodes.paragraph.create({}, content ? schema.text(content) : null);
+            const newNode = footerNodeType.create({}, paragraph);
+    
+            // If last node is footer, replace it, else insert at end
+            if (state.doc.lastChild?.type === footerNodeType) {
+              const lastNodePos = state.doc.content.size - state.doc.lastChild.nodeSize;
+              tr.replaceWith(lastNodePos, state.doc.content.size, newNode);
+            } else {
+              tr.insert(state.doc.content.size, newNode);
+            }
+            
+            // Add meta to trigger pagination update
+            tr.setMeta('HEADER_FOOTER_UPDATE_META_KEY', Date.now());
+    
+            dispatch(tr);
+            return true;
+          },
+      };
+    }
+  });

--- a/src/Header.ts
+++ b/src/Header.ts
@@ -1,0 +1,58 @@
+import { Node } from '@tiptap/core';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    header: {
+      setHeaderContent: (content: string) => ReturnType;
+    };
+  }
+}
+
+export const HeaderNode = Node.create({
+  name: 'header',
+  group: 'pageStructure',
+  content: 'block+',
+  defining: true,
+  isolated: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="header"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    // This node is a data container and is not rendered in the main document flow.
+    return ['div', { ...HTMLAttributes, 'data-type': 'header', style: 'display: none;' }, 0];
+  },
+
+
+  addCommands() {
+    return {
+      setHeaderContent:
+        (content: string) =>
+        ({ tr, state, dispatch, editor }) => {
+          if (!dispatch) return false;
+          
+          const { schema } = state;
+          const headerNodeType = schema.nodes.header;
+          
+          // Create a paragraph with the content
+          const paragraph = schema.nodes.paragraph.create({}, content ? schema.text(content) : null);
+          const newNode = headerNodeType.create({}, paragraph);
+  
+          // If first node is header, replace it, else insert at pos 0
+          if (state.doc.firstChild?.type === headerNodeType) {
+            tr.replaceWith(0, state.doc.firstChild.nodeSize, newNode);
+          } else {
+            tr.insert(0, newNode);
+          }
+          
+          // Add meta to trigger pagination update
+          tr.setMeta('HEADER_FOOTER_UPDATE_META_KEY', Date.now());
+  
+          dispatch(tr);
+          return true;
+        },
+    };
+  }
+});
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,7 @@ import { TablePlus } from './TablePlus'
 import { TableCellPlus } from './TableCellPlus'
 import { TableHeaderPlus } from './TableHeaderPlus'
 import { TableRowPlus } from './TableRowPlus'
+import { HeaderNode } from "./Header"
+import { FooterNode } from "./Footer"
 
-export { PaginationPlus, TablePlus, TableCellPlus, TableHeaderPlus, TableRowPlus }
+export { PaginationPlus, TablePlus, TableCellPlus, TableHeaderPlus, TableRowPlus, HeaderNode, FooterNode}


### PR DESCRIPTION
### Overview

This PR introduces support for persistent, document-embedded headers and footers in the `tiptap-pagination-plus` extension solving #4 . Header and footer content can now be set as part of the document structure using new `header` and `footer` nodes, making them editable, savable, and loadable like any other node. This enables more flexible and dynamic page headers/footers, and improves integration with document-based workflows.

### Key Changes

- **HeaderNode and FooterNode Extensions:**  
  - Added `HeaderNode` and `FooterNode` to the extension set.
  - These nodes can be inserted into the document and their content will be rendered as the header/footer on every page.
  - Provided commands: `setHeaderContent` and `setFooterContent` for programmatic updates.

- **Document Schema Update:**  
  - The document schema is extended to allow an optional `header` at the start and an optional `footer` at the end:  
    `content: "header? block+ footer?"`
  - Example usage in README now shows how to configure this.

- **PaginationPlus Integration:**  
  - Pagination decorations now use the content of the `header` and `footer` nodes if present.
  - If no such node exists, falls back to the configuration options (`headerLeft`, `footerRight`, etc.).
  - The `{page}` variable is still supported in both node and config string content.

- **Commands for Header/Footer Content:**  
  - New commands (`setHeaderContent`, `setFooterContent`) make it easy to set or update header/footer content programmatically.

- **README Update:**  
  - Documentation now explains the new header/footer node functionality, how to use the commands, and how the fallback mechanism works.
  - Clarifies that editing header/footer content in the UI is more complex, as the visible header/footer is rendered via decorations.

### How It Works

- If a `header` or `footer` node exists in the document, its content is used for the header/footer on every page.
- If not, the configuration options (`headerLeft`, `footerRight`, etc.) are used as a fallback.
- Header/footer content can be set using the provided commands, and is part of the document structure.

### Example Usage

```typescript
import { Editor } from '@tiptap/core'
import StarterKit from '@tiptap/starter-kit'
import Document from '@tiptap/extension-document'
import { PaginationPlus, TablePlus, TableRowPlus, TableCellPlus, TableHeaderPlus, HeaderNode, FooterNode } from 'tiptap-pagination-plus'

const editor = new Editor({
  extensions: [
    StarterKit.configure({ document: false }),
    TablePlus,
    TableRowPlus,
    TableCellPlus,
    TableHeaderPlus,
    HeaderNode,
    FooterNode,
    Document.extend({ content: 'header? block+ footer?' }),
    PaginationPlus.configure({
      pageHeight: 842,
      pageGap: 20,
      pageBreakBackground: "#f7f7f7",
      pageHeaderHeight: 50,
      footerRight: "Made with ❤️ by Romik", // fallback
      footerLeft: "Page {page}",            // fallback
      headerLeft: "Header Left",            // fallback
      headerRight: "Header Right",          // fallback
    }),
  ],
})

// Set header/footer content
editor.commands.setHeaderContent('My Custom Header')
editor.commands.setFooterContent('Page {page} - Confidential')
```

### Notes

- The header/footer nodes are not directly editable in the UI by default, as the visible header/footer is rendered via decorations.
- The content can be styled, saved, and loaded as part of the document JSON.