### PR TITLE
Hardbreak bug fix

### DIFF
--- a/src/PaginationPlus.ts
+++ b/src/PaginationPlus.ts
@@ -69,7 +69,7 @@ function buildDecorations(doc: PMNode): DecorationSet {
         const el = document.createElement('span');
         el.classList.add('rm-br-decoration');
         return el;
-      });
+      }, { side: -1 });
       decorations.push(widget);
     }
   });


### PR DESCRIPTION
Hi,

I saw this decoration done to hardbreaks, which i assume is to help empty page-breaks for empty lines maybe? Anyways, it is causing the regular hardbreak (shift-enter) to break. I found this solution which i don't think disturbs the rest of the code.

Thanks for creating this extension.