### PR TITLE
PaginationPlus commands now update storage instead of options, restoring correct behavior under TipTap v3 (options are not mutable runtime configuration).

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 /.npmignore
 /node_modules
 /package-lock.json
+/tiptap-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "tiptap-pagination-plus",
-  "version": "1.2.5",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiptap-pagination-plus",
-      "version": "1.2.5",
+      "version": "3.0.5",
       "license": "MIT",
       "devDependencies": {
-        "@tiptap/core": "^2.26.1",
-        "@tiptap/pm": "^2.26.1",
+        "@tiptap/core": "^3.22.2",
+        "@tiptap/pm": "^3.22.2",
         "@types/node": "^22.15.2",
         "tsc-watch": "^6.0.4",
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.0.0",
-        "@tiptap/pm": "^2.0.0"
+        "@tiptap/core": "^2.0.0 || ^3.0.0",
+        "@tiptap/pm": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@remirror/core-constants": {
@@ -28,9 +28,9 @@
       "license": "MIT"
     },
     "node_modules/@tiptap/core": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
-      "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.2.tgz",
+      "integrity": "sha512-atq35NkpeEphH6vNYJ0pTLLBA73FAbvTV9Ovd3AaTC5s99/KF5Q86zVJXvml8xPRcMGM6dLp+eSSd06oTscMSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -38,13 +38,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/pm": "^3.22.2"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
-      "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.2.tgz",
+      "integrity": "sha512-G2ENwIazoSKkAnN5MN5yN91TIZNFm6TxB74kPf3Empr2k9W51Hkcier70jHGpArhgcEaL4BVreuU1PRDRwCeGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -58,14 +58,14 @@
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-markdown": "^1.13.1",
         "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.23.0",
+        "prosemirror-model": "^1.24.1",
         "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-schema-list": "^1.5.0",
         "prosemirror-state": "^1.4.3",
         "prosemirror-tables": "^1.6.4",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.37.0"
+        "prosemirror-view": "^1.38.1"
       },
       "funding": {
         "type": "github",
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
-      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.0.tgz",
+      "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/prosemirror-history": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
-      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/prosemirror-inputrules": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
-      "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/prosemirror-keymap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
-      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.1.tgz",
-      "integrity": "sha512-AUvbm7qqmpZa5d9fPKMvH1Q5bqYQvAZWOGRvxsB6iFLyycvC9MwNemNVjHVrWgjaoxAfY8XVg7DbvQ/qxvI9Eg==",
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/prosemirror-state": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
-      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -439,17 +439,17 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.7.1.tgz",
-      "integrity": "sha512-eRQ97Bf+i9Eby99QbyAiyov43iOKgWa7QCGly+lrDt7efZ1v8NWolhXiB43hSDGIXT1UXgbs4KJN3a06FGpr1Q==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.25.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-transform": "^1.10.3",
-        "prosemirror-view": "^1.39.1"
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
       }
     },
     "node_modules/prosemirror-trailing-node": {
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
-      "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.39.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.39.2.tgz",
-      "integrity": "sha512-BmOkml0QWNob165gyUxXi5K5CVUgVPpqMEAAml/qzgKn9boLUWVPzQ6LtzXw8Cn1GtRQX4ELumPxqtLTDaAKtg==",
+      "version": "1.41.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
+      "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiptap-pagination-plus",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Tiptap pagination extension with advanced options like automatic page breaks, customizable layouts and more.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,8 +29,8 @@
   "author": "Romik Makavana",
   "license": "MIT",
   "devDependencies": {
-    "@tiptap/core": "^2.26.1",
-    "@tiptap/pm": "^2.26.1",
+    "@tiptap/core": "^3.22.2",
+    "@tiptap/pm": "^3.22.2",
     "@types/node": "^22.15.2",
     "tsc-watch": "^6.0.4",
     "typescript": "^5.8.3"

--- a/src/PaginationPlus.ts
+++ b/src/PaginationPlus.ts
@@ -7,25 +7,27 @@ import { PageSize } from "./constants";
 import { HeaderOptions, FooterOptions, PageNumber, HeaderHeightMap, FooterHeightMap, HeaderClickEvent, FooterClickEvent } from "./types";
 import type { Node as PMNode } from 'prosemirror-model';
 
-
-export interface PaginationPlusOptions {
+export interface PaginationPlusConfig {
+  pageBreakBackground: string;
   pageHeight: number;
   pageWidth: number;
+  marginTop: number;
+  marginBottom: number;
+  marginLeft: number;
+  marginRight: number;
   pageGap: number;
-  pageBreakBackground: string;
-  pageGapBorderSize: number;
+  contentMarginTop: number;
+  contentMarginBottom: number;
   footerRight: string;
   footerLeft: string;
   headerRight: string;
   headerLeft: string;
   customHeader: Record<PageNumber, HeaderOptions>;
   customFooter: Record<PageNumber, FooterOptions>;
-  marginTop: number;
-  marginBottom: number;
-  marginLeft: number;
-  marginRight: number;
-  contentMarginTop: number;
-  contentMarginBottom: number;
+}
+
+export interface PaginationPlusOptions extends PaginationPlusConfig {
+  pageGapBorderSize: number;
   pageGapBorderColor: string;
   onHeaderClick?: HeaderClickEvent
   onFooterClick?: FooterClickEvent
@@ -34,7 +36,9 @@ export interface PaginationPlusOptions {
 export interface PaginationPlusStorage extends PaginationPlusOptions {
   headerHeight: HeaderHeightMap;
   footerHeight: FooterHeightMap;
+  appliedConfig: PaginationPlusConfig;
 }
+
 const page_count_meta_key = "PAGE_COUNT_META_KEY";
 const footer_height_meta_key = "FOOTER_HEIGHT_META_KEY";
 
@@ -76,26 +80,33 @@ function buildDecorations(doc: PMNode): DecorationSet {
   return DecorationSet.create(doc, decorations);
 
 }
-const defaultOptions: PaginationPlusOptions = {
+
+const defaultPageConfig: PaginationPlusConfig = {
+  pageBreakBackground: "#ffffff",
   pageHeight: 800,
   pageWidth: 789,
-  pageGap: 50,
-  pageGapBorderSize: 1,
-  pageBreakBackground: "#ffffff",
-  footerRight: "{page}",
-  footerLeft: "",
-  headerRight: "",
-  headerLeft: "",
   marginTop: 20,
   marginBottom: 20,
   marginLeft: 50,
   marginRight: 50,
+  pageGap: 50,
   contentMarginTop: 10,
   contentMarginBottom: 10,
-  pageGapBorderColor: "#e5e5e5",
+  footerRight: "{page}",
+  footerLeft: "",
+  headerRight: "",
+  headerLeft: "",
   customHeader: {},
   customFooter: {},
 }
+
+const defaultOptions: PaginationPlusOptions = {
+  pageGapBorderSize: 1,
+  pageGapBorderColor: "#e5e5e5",
+  ...defaultPageConfig,
+}
+
+
 
 const refreshPage = (targetNode: HTMLElement) => {
   const paginationElement = targetNode.querySelector(
@@ -113,6 +124,76 @@ const refreshPage = (targetNode: HTMLElement) => {
   }
 };
 
+const getAppliedPageConfig = (_storage: PaginationPlusStorage, _currentOptions: PaginationPlusOptions): PaginationPlusOptions => {
+  return {
+    ..._currentOptions,
+    pageBreakBackground: _storage.appliedConfig.pageBreakBackground ?? defaultOptions.pageBreakBackground,
+    pageHeight: _storage.appliedConfig.pageHeight ?? defaultOptions.pageHeight,
+    pageWidth: _storage.appliedConfig.pageWidth ?? defaultPageConfig.pageWidth,
+    marginTop: _storage.appliedConfig.marginTop ?? defaultPageConfig.marginTop,
+    marginBottom: _storage.appliedConfig.marginBottom ?? defaultPageConfig.marginBottom,
+    marginLeft: _storage.appliedConfig.marginLeft ?? defaultPageConfig.marginLeft,
+    marginRight: _storage.appliedConfig.marginRight ?? defaultPageConfig.marginRight,
+    pageGap: _storage.appliedConfig.pageGap ?? defaultPageConfig.pageGap,
+    contentMarginTop: _storage.appliedConfig.contentMarginTop ?? defaultPageConfig.contentMarginTop,
+    contentMarginBottom: _storage.appliedConfig.contentMarginBottom ?? defaultPageConfig.contentMarginBottom,
+    footerRight: _storage.appliedConfig.footerRight ?? defaultPageConfig.footerRight,
+    footerLeft: _storage.appliedConfig.footerLeft ?? defaultPageConfig.footerLeft,
+    headerRight: _storage.appliedConfig.headerRight ?? defaultPageConfig.headerRight,
+    headerLeft: _storage.appliedConfig.headerLeft ?? defaultPageConfig.headerLeft,
+    customHeader: _storage.appliedConfig.customHeader ?? defaultPageConfig.customHeader,
+    customFooter: _storage.appliedConfig.customFooter ?? defaultPageConfig.customFooter,
+  };
+}
+
+const getPageConfig = (_storage: PaginationPlusStorage, _currentOptions: PaginationPlusOptions): { config: PaginationPlusConfig, options: PaginationPlusOptions } => {
+  const pageConfig: PaginationPlusConfig = {
+    pageBreakBackground: _storage.pageBreakBackground ?? defaultOptions.pageBreakBackground,
+    pageHeight: _storage.pageHeight ?? defaultOptions.pageHeight,
+    pageWidth: _storage.pageWidth ?? defaultPageConfig.pageWidth,
+    marginTop: _storage.marginTop ?? defaultPageConfig.marginTop,
+    marginBottom: _storage.marginBottom ?? defaultPageConfig.marginBottom,
+    marginLeft: _storage.marginLeft ?? defaultPageConfig.marginLeft,
+    marginRight: _storage.marginRight ?? defaultPageConfig.marginRight,
+    pageGap: _storage.pageGap ?? defaultPageConfig.pageGap,
+    contentMarginTop: _storage.contentMarginTop ?? defaultPageConfig.contentMarginTop,
+    contentMarginBottom: _storage.contentMarginBottom ?? defaultPageConfig.contentMarginBottom,
+    footerRight: _storage.footerRight ?? defaultPageConfig.footerRight,
+    footerLeft: _storage.footerLeft ?? defaultPageConfig.footerLeft,
+    headerRight: _storage.headerRight ?? defaultPageConfig.headerRight,
+    headerLeft: _storage.headerLeft ?? defaultPageConfig.headerLeft,
+    customHeader: _storage.customHeader ?? defaultPageConfig.customHeader,
+    customFooter: _storage.customFooter ?? defaultPageConfig.customFooter,
+  };
+  return {
+    config: pageConfig,
+    options: {
+    ..._currentOptions,
+    ...pageConfig}
+  };
+}
+
+const getPageConfigFromOptions = (_currentOptions: PaginationPlusOptions): PaginationPlusConfig => {
+  return {
+    pageBreakBackground: _currentOptions.pageBreakBackground ?? defaultOptions.pageBreakBackground,
+    pageHeight: _currentOptions.pageHeight ?? defaultOptions.pageHeight,
+    pageWidth: _currentOptions.pageWidth ?? defaultPageConfig.pageWidth,
+    marginTop: _currentOptions.marginTop ?? defaultPageConfig.marginTop,
+    marginBottom: _currentOptions.marginBottom ?? defaultPageConfig.marginBottom,
+    marginLeft: _currentOptions.marginLeft ?? defaultPageConfig.marginLeft,
+    marginRight: _currentOptions.marginRight ?? defaultPageConfig.marginRight,
+    pageGap: _currentOptions.pageGap ?? defaultPageConfig.pageGap,
+    contentMarginTop: _currentOptions.contentMarginTop ?? defaultPageConfig.contentMarginTop,
+    contentMarginBottom: _currentOptions.contentMarginBottom ?? defaultPageConfig.contentMarginBottom,
+    footerRight: _currentOptions.footerRight ?? defaultPageConfig.footerRight,
+    footerLeft: _currentOptions.footerLeft ?? defaultPageConfig.footerLeft,
+    headerRight: _currentOptions.headerRight ?? defaultPageConfig.headerRight,
+    headerLeft: _currentOptions.headerLeft ?? defaultPageConfig.headerLeft,
+    customHeader: _currentOptions.customHeader ?? defaultPageConfig.customHeader,
+    customFooter: _currentOptions.customFooter ?? defaultPageConfig.customFooter,
+  };
+}
+
 const paginationKey = new PluginKey("pagination");
 
 export const PaginationPlus = Extension.create<PaginationPlusOptions, PaginationPlusStorage>({
@@ -125,9 +206,14 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
       ...defaultOptions,
       headerHeight: new Map(),
       footerHeight: new Map(),
+      appliedConfig: defaultPageConfig,
     };
   },
   onCreate() {
+
+    const { options: _currentOptions } = getPageConfig(this.storage, this.options);
+    const pageConfig = getPageConfigFromOptions(this.options);
+
     const targetNode = this.editor.view.dom;
     targetNode.classList.add("rm-with-pagination");
     targetNode.style.border = `1px solid var(--rm-page-gap-border-color)`;
@@ -135,7 +221,7 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
     targetNode.style.paddingRight = `var(--rm-margin-right)`;
     targetNode.style.width = `var(--rm-page-width)`;
 
-    updateCssVariables(targetNode, this.options);
+    updateCssVariables(targetNode, {..._currentOptions, ...pageConfig});
 
     const style = document.createElement("style");
     style.dataset.rmPaginationStyle = "";
@@ -259,55 +345,86 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
   },
   addProseMirrorPlugins() {
     const editor = this.editor;
+    const storage = this.storage;
     return [
       new Plugin({
         key: paginationKey,
 
         state: {
           init: (_, state) => {
-            const widgetList = createDecoration(this.options, new Map(), new Map());
-            this.storage = { ...this.options, headerHeight: new Map(), footerHeight: new Map() };
+            const _currentOptions =  getPageConfigFromOptions(this.options);
+
+            const pageConfig = getPageConfigFromOptions(this.options);
+            const widgetList = createDecoration({...this.options, ..._currentOptions}, new Map(), new Map());
+
+            storage.pageBreakBackground = _currentOptions.pageBreakBackground;
+            storage.pageHeight = _currentOptions.pageHeight;
+            storage.pageWidth = _currentOptions.pageWidth;
+            storage.marginTop = _currentOptions.marginTop;
+            storage.marginBottom = _currentOptions.marginBottom;
+            storage.marginLeft = _currentOptions.marginLeft;
+            storage.marginRight = _currentOptions.marginRight;
+            storage.pageGap = _currentOptions.pageGap;
+            storage.contentMarginTop = _currentOptions.contentMarginTop;
+            storage.contentMarginBottom = _currentOptions.contentMarginBottom;
+            storage.footerRight = _currentOptions.footerRight;
+            storage.footerLeft = _currentOptions.footerLeft;
+            storage.headerRight = _currentOptions.headerRight;
+            storage.headerLeft = _currentOptions.headerLeft;
+            storage.customHeader = _currentOptions.customHeader;
+            storage.customFooter = _currentOptions.customFooter;
+            storage.headerHeight = new Map();
+            storage.footerHeight = new Map();
+            storage.appliedConfig = pageConfig;
 
             return {
               decorations : DecorationSet.create(state.doc, widgetList),
             };
           },
           apply: (tr, oldDeco, oldState, newState) => {
-            const pageCount = calculatePageCount(editor.view, this.options);
-            const currentPageCount = getExistingPageCount(editor.view);
+            const { options: _currentOptions, config: pageConfig } =  getPageConfig(storage, this.options);
 
+            const pageCount = getNewPageCount(editor.view, {..._currentOptions, ...pageConfig});
+            const currentPageCount = getExistingPageCount(editor.view);
             const getNewDecoration = () => {
-              updateCssVariables(editor.view.dom, this.options);
+              const { options: _currentOptions, config: pageConfig } =  getPageConfig(storage, this.options);
+
+              updateCssVariables(editor.view.dom, _currentOptions);
+
               let headerHeight = "headerHeight" in this.storage ? this.storage.headerHeight : new Map();
               let footerHeight = "footerHeight" in this.storage ? this.storage.footerHeight : new Map();
 
-              const widgetList = createDecoration(this.options, headerHeight, footerHeight);
-              this.storage = { ...this.options, headerHeight, footerHeight };
+              const widgetList = createDecoration({..._currentOptions, ...pageConfig}, headerHeight, footerHeight);
+
+
+              storage.appliedConfig = pageConfig;
+              storage.headerHeight = headerHeight;
+              storage.footerHeight = footerHeight;
+
               return {
                 decorations : DecorationSet.create(newState.doc, [...widgetList]),
                 footerHeight
               };
             }
 
-
             if (
               (pageCount > 1 ? pageCount : 1) !== currentPageCount ||
-              this.storage.pageBreakBackground !== this.options.pageBreakBackground ||
-              this.storage.pageHeight !== this.options.pageHeight ||
-              this.storage.pageWidth !== this.options.pageWidth ||
-              this.storage.marginTop !== this.options.marginTop ||
-              this.storage.marginBottom !== this.options.marginBottom ||
-              this.storage.marginLeft !== this.options.marginLeft ||
-              this.storage.marginRight !== this.options.marginRight ||
-              this.storage.pageGap !== this.options.pageGap ||
-              this.storage.contentMarginTop !== this.options.contentMarginTop ||
-              this.storage.contentMarginBottom !== this.options.contentMarginBottom ||
-              this.storage.headerLeft !== this.options.headerLeft ||
-              this.storage.headerRight !== this.options.headerRight ||
-              this.storage.footerLeft !== this.options.footerLeft ||
-              this.storage.footerRight !== this.options.footerRight ||
-              !deepEqualIterative(this.options.customHeader, this.storage.customHeader) ||
-              !deepEqualIterative(this.options.customFooter, this.storage.customFooter)
+              storage.pageBreakBackground !== storage.appliedConfig.pageBreakBackground ||
+              storage.pageHeight !== storage.appliedConfig.pageHeight ||
+              storage.pageWidth !== storage.appliedConfig.pageWidth ||
+              storage.marginTop !== storage.appliedConfig.marginTop ||
+              storage.marginBottom !== storage.appliedConfig.marginBottom ||
+              storage.marginLeft !== storage.appliedConfig.marginLeft ||
+              storage.marginRight !== storage.appliedConfig.marginRight ||
+              storage.pageGap !== storage.appliedConfig.pageGap ||
+              storage.contentMarginTop !== storage.appliedConfig.contentMarginTop ||
+              storage.contentMarginBottom !== storage.appliedConfig.contentMarginBottom ||
+              storage.headerLeft !== storage.appliedConfig.headerLeft ||
+              storage.headerRight !== storage.appliedConfig.headerRight ||
+              storage.footerLeft !== storage.appliedConfig.footerLeft ||
+              storage.footerRight !== storage.appliedConfig.footerRight ||
+              !deepEqualIterative(storage.appliedConfig.customHeader, storage.customHeader) ||
+              !deepEqualIterative(storage.appliedConfig.customFooter, storage.customFooter)
             ) {
               return getNewDecoration();
             }
@@ -325,7 +442,9 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
         view: (editorView: EditorView) => {
           return {
             update: (view : EditorView) => {
-                const pageCount = calculatePageCount(view, this.options);
+              const { options: _currentOptions, config: pageConfig } =  getPageConfig(storage, this.options);
+
+                const pageCount = getNewPageCount(view, {..._currentOptions, ...pageConfig});
                 const currentPageCount = getExistingPageCount(view);
                 
                 const triggerUpdate = (_footerHeight?: FooterHeightMap) => {
@@ -340,8 +459,8 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
                   return;
                 }
 
-                const headerHeight = getHeaderHeight(view.dom, getCustomPages(this.options.customHeader, {}), "content");
-                const footerHeight = getFooterHeight(view.dom, getCustomPages({}, this.options.customFooter), "content");
+                const headerHeight = getHeaderHeight(view.dom, getCustomPages(_currentOptions.customHeader, {}), "content");
+                const footerHeight = getFooterHeight(view.dom, getCustomPages({}, _currentOptions.customFooter), "content");
 
                 const footerHeightForCurrentPages = new Map<PageNumber, number>();
                 for(let i = 0; i <= pageCount; i++) {
@@ -382,7 +501,7 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
                   
                   const headerHeight = headerHeightForCurrentPages.has(page) ? headerHeightForCurrentPages.get(page) || 0 : headerHeightForCurrentPages.get(0) || 0;
                   const footerHeight = footerHeightForCurrentPages.has(page) ? footerHeightForCurrentPages.get(page) || 0 : footerHeightForCurrentPages.get(0) || 0;
-                  const { _pageHeaderHeight, _pageHeight } = getHeight(this.options, headerHeight, footerHeight);
+                  const { _pageHeaderHeight, _pageHeight } = getHeight(_currentOptions, headerHeight, footerHeight);
                   
                   const contentHeight = page === 1 ? _pageHeight + _pageHeaderHeight : _pageHeight;
                   if(page === 1) {
@@ -447,57 +566,58 @@ export const PaginationPlus = Extension.create<PaginationPlusOptions, Pagination
   addCommands() {
     return {
       updatePageBreakBackground: (color: string) => () => {
-        this.options.pageBreakBackground = color;
+        this.storage.pageBreakBackground = color;
         return true;
       },
       updatePageSize: (size: PageSize) => () => {
-        this.options.pageHeight = size.pageHeight;
-        this.options.pageWidth = size.pageWidth;
-        this.options.marginTop = size.marginTop;
-        this.options.marginBottom = size.marginBottom;
-        this.options.marginLeft = size.marginLeft;
-        this.options.marginRight = size.marginRight;
+        
+        this.storage.pageHeight = size.pageHeight;
+        this.storage.pageWidth = size.pageWidth;
+        this.storage.marginTop = size.marginTop;
+        this.storage.marginBottom = size.marginBottom;
+        this.storage.marginLeft = size.marginLeft;
+        this.storage.marginRight = size.marginRight;
         return true;
       },
       updatePageWidth: (width: number) => () => {
-        this.options.pageWidth = width;
+        this.storage.pageWidth = width;
         return true;
       },
       updatePageHeight: (height: number) => () => {
-        this.options.pageHeight = height;
+        this.storage.pageHeight = height;
         return true;
       },
       updatePageGap: (gap: number) => () => {
-        this.options.pageGap = gap;
+        this.storage.pageGap = gap;
         return true;
       },
       updateMargins: (margins: { top: number, bottom: number, left: number, right: number }) => () => {
-        this.options.marginTop = margins.top;
-        this.options.marginBottom = margins.bottom;
-        this.options.marginLeft = margins.left;
-        this.options.marginRight = margins.right;
+        this.storage.marginTop = margins.top;
+        this.storage.marginBottom = margins.bottom;
+        this.storage.marginLeft = margins.left;
+        this.storage.marginRight = margins.right;
         return true;
       },
       updateContentMargins: (margins: { top: number, bottom: number }) => () => {
-        this.options.contentMarginTop = margins.top;
-        this.options.contentMarginBottom = margins.bottom;
+        this.storage.contentMarginTop = margins.top;
+        this.storage.contentMarginBottom = margins.bottom;
         return true;
       },
       updateHeaderContent: (left: string, right: string, pageNumber?: PageNumber) => () => {
         if(pageNumber) {
-          this.options.customHeader = { ...this.options.customHeader, [pageNumber]: { headerLeft: left, headerRight: right } };
+          this.storage.customHeader = { ...this.storage.customHeader, [pageNumber]: { headerLeft: left, headerRight: right } };
         }else{
-          this.options.headerLeft = left;
-          this.options.headerRight = right;
+          this.storage.headerLeft = left;
+          this.storage.headerRight = right;
         }
         return true;
       },
       updateFooterContent: (left: string, right: string, pageNumber?: PageNumber) => () => {
         if(pageNumber) {
-          this.options.customFooter = { ...this.options.customFooter, [pageNumber]: { footerLeft: left, footerRight: right } };
+          this.storage.customFooter = { ...this.storage.customFooter, [pageNumber]: { footerLeft: left, footerRight: right } };
         }else{
-          this.options.footerLeft = left;
-          this.options.footerRight = right;
+          this.storage.footerLeft = left;
+          this.storage.footerRight = right;
         }
         return true;
       },
@@ -545,16 +665,12 @@ const calculatePageCount = (
         const addPage = Math.ceil(lastPageGap / pageContentAreaHeight);
         return currentPageCount + addPage;
       } else {
-        const lpFrom = -10;
-        const lpTo = -(pageOptions.pageHeight - 10);
-        if (lastPageGap > lpTo && lastPageGap < lpFrom) {
-          return currentPageCount;
-        } else if (lastPageGap < lpTo) {
-          const pageHeightOnRemove =
-            pageOptions.pageHeight + pageOptions.pageGap;
-          const removePage = Math.floor(lastPageGap / pageHeightOnRemove);
-          return currentPageCount + removePage;
-        } else {
+        const allBreaksAfterLastElement = Array.from(paginationElement.querySelectorAll(".breaker"));
+        const allBreaksAfterLastElementRect = allBreaksAfterLastElement.filter(element => element.getBoundingClientRect().top > lastElementRect.bottom);
+        const removePage = allBreaksAfterLastElementRect.length;
+        if(removePage > 1) {
+          return currentPageCount - removePage;
+        }else{
           return currentPageCount;
         }
       }
@@ -567,6 +683,11 @@ const calculatePageCount = (
     return pageCount;
   }
 };
+
+const getNewPageCount = (view: EditorView, pageOptions: PaginationPlusOptions) => {
+  const pageCount = calculatePageCount(view, pageOptions);
+  return pageCount <= 1 ? 1 : pageCount;
+}
 
 function createDecoration(
   pageOptions: PaginationPlusOptions,
@@ -645,7 +766,7 @@ function createDecoration(
 
       const fragment = document.createDocumentFragment();
 
-      const pageCount = calculatePageCount(view, pageOptions);
+      const pageCount = getNewPageCount(view, pageOptions);
 
       for (let i = 0; i < pageCount; i++) {
         const pageNumber = i+1;


### PR DESCRIPTION
We’ve released tiptap-pagination-plus 3.0.6, which includes an important fix for TipTap v3.
What was wrong: Runtime updates from extension commands (page size, margins, gaps, header/footer content, etc.) were previously written to options. In TipTap v3, options are not reliable for mutable runtime state, so those updates often had no effect—commands could appear broken.
What we changed: Pagination settings that commands update now live in extension storage, which TipTap treats as mutable instance state. Commands update storage; the pagination plugin and layout logic read that state, so chain commands work as intended.
What you should do: Upgrade to tiptap-pagination-plus@3.0.6 (or latest 3.0.x). If you had workarounds or avoided commands after upgrading to TipTap v3, you can retry the official command API.
Compatibility: Peer dependencies remain @tiptap/core / @tiptap/pm ^2.0.0 || ^3.0.0 as published.
